### PR TITLE
Add Wine and Wineserver Bin Path Variables to Generated Scripts

### DIFF
--- a/fast_install_AppImageWine_and_Logos.sh
+++ b/fast_install_AppImageWine_and_Logos.sh
@@ -266,6 +266,8 @@ IFS=$'\n'
 [ -x "\${HERE}/data/bin/${WINE_EXE}" ] && export PATH="\${HERE}/data/bin:\${PATH}"
 export WINEARCH=win${WINE_BITS}
 export WINEPREFIX="\${HERE}/data/wine${WINE_BITS}_bottle"
+export LOGOS_WINE_BIN_PATH="$(which wine64 | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
+export LOGOS_WINESERVER_BIN_PATH="$(which wineserver | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
 #-------
 [ -z "\${LOGOS_ICON_URL}" ] && export LOGOS_ICON_URL="${LOGOS_ICON_URL}"
 LOGOS_ICON_FILENAME="\$(basename "\${LOGOS_ICON_URL}")"; export LOGOS_ICON_FILENAME
@@ -390,6 +392,8 @@ IFS=$'\n'
 [ -x "\${HERE}/data/bin/${WINE_EXE}" ] && export PATH="\${HERE}/data/bin:\${PATH}"
 export WINEARCH=win${WINE_BITS}
 export WINEPREFIX="\${HERE}/data/wine${WINE_BITS}_bottle"
+export LOGOS_WINE_BIN_PATH="$(which wine64 | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
+export LOGOS_WINESERVER_BIN_PATH="$(which wineserver | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
 #-------
 [ -z "\${WINETRICKS_URL}" ] && export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks"
 [ -z "\${WINETRICKS_DOWNLOADER+x}" ] && export WINETRICKS_DOWNLOADER="wget"

--- a/fast_install_AppImageWine_and_Logos.sh
+++ b/fast_install_AppImageWine_and_Logos.sh
@@ -411,11 +411,11 @@ case "\${1}" in
 		exit 0
 		;;
 	"wineserver")
-		# wineserver Run:
-		echo "======= Running wineserver only: ======="
+		# \${LOGOS_WINESERVER_BIN_PATH}wineserver Run:
+		echo "======= Running \${LOGOS_WINESERVER_BIN_PATH}wineserver only: ======="
 		shift
 		\${LOGOS_WINESERVER_BIN_PATH}wineserver "\$@"
-		echo "======= wineserver run done! ======="
+		echo "======= \${LOGOS_WINESERVER_BIN_PATH}wineserver run done! ======="
 		exit 0
 		;;
 	"winetricks")
@@ -460,7 +460,7 @@ case "\${1}" in
 				ln -s "\${APPIMAGE_FULLPATH}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 				rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 				mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-				(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+				(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 				echo "======= AppImage Selection run done with external link! ======="
 				exit 0
 			fi
@@ -471,7 +471,7 @@ case "\${1}" in
 		ln -s "../\${APPIMAGE_FILENAME}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 		rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 		mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-		(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+		(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 		echo "======= AppImage Selection run done! ======="
 		exit 0
 		;;

--- a/fast_install_AppImageWine_and_Logos.sh
+++ b/fast_install_AppImageWine_and_Logos.sh
@@ -288,10 +288,10 @@ case "\${1}" in
 			exit 1
 		fi
 		echo "* Closing anything running in this wine bottle:"
-		wineserver -k
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -k
 		echo "* Running the indexer:"
-		${WINE_EXE} "\${LOGOS_INDEXER_EXE}"
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\${LOGOS_INDEXER_EXE}"
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= indexing of LogosBible run done! ======="
 		exit 0
 		;;
@@ -308,15 +308,15 @@ case "\${1}" in
 		;;
 	"logsOn")
 		echo "======= enable LogosBible logging only: ======="
-		${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0001 /f
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0001 /f
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= enable LogosBible logging done! ======="
 		exit 0
 		;;
 	"logsOff")
 		echo "======= disable LogosBible logging only: ======="
-		${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0000 /f
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0000 /f
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= disable LogosBible logging done! ======="
 		exit 0
 		;;
@@ -362,8 +362,8 @@ if [ -z "\${LOGOS_EXE}" ] ; then
 	exit 0
 fi
 
-${WINE_EXE} "\${LOGOS_EXE}"
-wineserver -w
+\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\${LOGOS_EXE}"
+\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 #-------------------------------------------------
 
 #------------- Ending block ----------------------
@@ -402,19 +402,19 @@ export LOGOS_WINESERVER_BIN_PATH="$(which wineserver | awk -F'/' 'BEGIN {OFS = F
 #-------------------------------------------------
 case "\${1}" in
 	"${WINE_EXE}")
-		# ${WINE_EXE} Run:
-		echo "======= Running ${WINE_EXE} only: ======="
+		# \${LOGOS_WINE_BIN_PATH}${WINE_EXE} Run:
+		echo "======= Running \${LOGOS_WINE_BIN_PATH}${WINE_EXE} only: ======="
 		shift
-		${WINE_EXE} "\$@"
-		wineserver -w
-		echo "======= ${WINE_EXE} run done! ======="
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\$@"
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
+		echo "======= \${LOGOS_WINE_BIN_PATH}${WINE_EXE} run done! ======="
 		exit 0
 		;;
 	"wineserver")
 		# wineserver Run:
 		echo "======= Running wineserver only: ======="
 		shift
-		wineserver "\$@"
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver "\$@"
 		echo "======= wineserver run done! ======="
 		exit 0
 		;;
@@ -429,7 +429,7 @@ case "\${1}" in
 		shift
 		"\${WORKDIR}"/winetricks "\$@"
 		rm -rf "\${WORKDIR}"
-		wineserver -w
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= winetricks run done! ======="
 		exit 0
 		;;
@@ -460,7 +460,7 @@ case "\${1}" in
 				ln -s "\${APPIMAGE_FULLPATH}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 				rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 				mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-				(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+				(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 				echo "======= AppImage Selection run done with external link! ======="
 				exit 0
 			fi
@@ -471,7 +471,7 @@ case "\${1}" in
 		ln -s "../\${APPIMAGE_FILENAME}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 		rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 		mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-		(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+		(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 		echo "======= AppImage Selection run done! ======="
 		exit 0
 		;;
@@ -479,8 +479,8 @@ case "\${1}" in
 		echo "No arguments parsed."
 esac
 
-${WINE_EXE} control
-wineserver -w
+\${LOGOS_WINE_BIN_PATH}${WINE_EXE} control
+\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 #-------------------------------------------------
 
 #------------- Ending block ----------------------

--- a/install_AppImageWine_and_Logos.sh
+++ b/install_AppImageWine_and_Logos.sh
@@ -275,6 +275,8 @@ IFS=$'\n'
 [ -x "\${HERE}/data/bin/${WINE_EXE}" ] && export PATH="\${HERE}/data/bin:\${PATH}"
 export WINEARCH=win${WINE_BITS}
 export WINEPREFIX="\${HERE}/data/wine${WINE_BITS}_bottle"
+export LOGOS_WINE_BIN_PATH="$(which wine64 | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
+export LOGOS_WINESERVER_BIN_PATH="$(which wineserver | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
 #-------
 [ -z "\${LOGOS_ICON_URL}" ] && export LOGOS_ICON_URL="${LOGOS_ICON_URL}"
 LOGOS_ICON_FILENAME="\$(basename "\${LOGOS_ICON_URL}")"; export LOGOS_ICON_FILENAME
@@ -399,6 +401,8 @@ IFS=$'\n'
 [ -x "\${HERE}/data/bin/${WINE_EXE}" ] && export PATH="\${HERE}/data/bin:\${PATH}"
 export WINEARCH=win${WINE_BITS}
 export WINEPREFIX="\${HERE}/data/wine${WINE_BITS}_bottle"
+export LOGOS_WINE_BIN_PATH="$(which wine64 | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
+export LOGOS_WINESERVER_BIN_PATH="$(which wineserver | awk -F'/' 'BEGIN {OFS = FS} $NF=""; {print $0}')"
 #-------
 [ -z "\${WINETRICKS_URL}" ] && export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks"
 [ -z "\${WINETRICKS_DOWNLOADER+x}" ] && export WINETRICKS_DOWNLOADER="wget"

--- a/install_AppImageWine_and_Logos.sh
+++ b/install_AppImageWine_and_Logos.sh
@@ -297,10 +297,10 @@ case "\${1}" in
 			exit 1
 		fi
 		echo "* Closing anything running in this wine bottle:"
-		wineserver -k
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -k
 		echo "* Running the indexer:"
-		${WINE_EXE} "\${LOGOS_INDEXER_EXE}"
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\${LOGOS_INDEXER_EXE}"
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= indexing of LogosBible run done! ======="
 		exit 0
 		;;
@@ -317,15 +317,15 @@ case "\${1}" in
 		;;
 	"logsOn")
 		echo "======= enable LogosBible logging only: ======="
-		${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0001 /f
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0001 /f
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= enable LogosBible logging done! ======="
 		exit 0
 		;;
 	"logsOff")
 		echo "======= disable LogosBible logging only: ======="
-		${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0000 /f
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} reg add "HKCU\\\\Software\\\\Logos4\\\\Logging" /v Enabled /t REG_DWORD /d 0000 /f
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= disable LogosBible logging done! ======="
 		exit 0
 		;;
@@ -371,8 +371,8 @@ if [ -z "\${LOGOS_EXE}" ] ; then
 	exit 0
 fi
 
-${WINE_EXE} "\${LOGOS_EXE}"
-wineserver -w
+\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\${LOGOS_EXE}"
+\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 #-------------------------------------------------
 
 #------------- Ending block ----------------------
@@ -411,20 +411,20 @@ export LOGOS_WINESERVER_BIN_PATH="$(which wineserver | awk -F'/' 'BEGIN {OFS = F
 #-------------------------------------------------
 case "\${1}" in
 	"${WINE_EXE}")
-		# ${WINE_EXE} Run:
+		# \${LOGOS_WINE_BIN_PATH}${WINE_EXE} Run:
 		echo "======= Running ${WINE_EXE} only: ======="
 		shift
-		${WINE_EXE} "\$@"
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\$@"
+		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
 		echo "======= ${WINE_EXE} run done! ======="
 		exit 0
 		;;
 	"wineserver")
-		# wineserver Run:
-		echo "======= Running wineserver only: ======="
+		# \${LOGOS_WINE_BIN_PATH}wineserver Run:
+		echo "======= Running \${LOGOS_WINE_BIN_PATH}wineserver only: ======="
 		shift
-		wineserver "\$@"
-		echo "======= wineserver run done! ======="
+		\${LOGOS_WINE_BIN_PATH}wineserver "\$@"
+		echo "======= \${LOGOS_WINE_BIN_PATH}wineserver run done! ======="
 		exit 0
 		;;
 	"winetricks")
@@ -438,7 +438,7 @@ case "\${1}" in
 		shift
 		"\${WORKDIR}"/winetricks "\$@"
 		rm -rf "\${WORKDIR}"
-		wineserver -w
+		\${LOGOS_WINE_BIN_PATH}wineserver -w
 		echo "======= winetricks run done! ======="
 		exit 0
 		;;
@@ -469,7 +469,7 @@ case "\${1}" in
 				ln -s "\${APPIMAGE_FULLPATH}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 				rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 				mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-				(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+				(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 				echo "======= AppImage Selection run done with external link! ======="
 				exit 0
 			fi
@@ -480,7 +480,7 @@ case "\${1}" in
 		ln -s "../\${APPIMAGE_FILENAME}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 		rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 		mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-		(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+		(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 		echo "======= AppImage Selection run done! ======="
 		exit 0
 		;;
@@ -488,8 +488,8 @@ case "\${1}" in
 		echo "No arguments parsed."
 esac
 
-${WINE_EXE} control
-wineserver -w
+\${LOGOS_WINE_BIN_PATH}${WINE_EXE} control
+\${LOGOS_WINE_BIN_PATH}wineserver -w
 #-------------------------------------------------
 
 #------------- Ending block ----------------------

--- a/install_AppImageWine_and_Logos.sh
+++ b/install_AppImageWine_and_Logos.sh
@@ -416,7 +416,7 @@ case "\${1}" in
 		shift
 		\${LOGOS_WINE_BIN_PATH}${WINE_EXE} "\$@"
 		\${LOGOS_WINESERVER_BIN_PATH}wineserver -w
-		echo "======= ${WINE_EXE} run done! ======="
+		echo "======= $\${LOGOS_WINE_BIN_PATH}{WINE_EXE} run done! ======="
 		exit 0
 		;;
 	"wineserver")
@@ -469,7 +469,7 @@ case "\${1}" in
 				ln -s "\${APPIMAGE_FULLPATH}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 				rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 				mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-				(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+				(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 				echo "======= AppImage Selection run done with external link! ======="
 				exit 0
 			fi
@@ -480,7 +480,7 @@ case "\${1}" in
 		ln -s "../\${APPIMAGE_FILENAME}" "\${APPIMAGE_LINK_SELECTION_NAME}"
 		rm -rf "\${HERE}/data/bin/\${APPIMAGE_LINK_SELECTION_NAME}"
 		mv "\${APPIMAGE_LINK_SELECTION_NAME}" "\${HERE}/data/bin/"
-		(DISPLAY="" "\${HERE}/controlPanel.sh" \${LOGOS_WINE_BIN_PATH}${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
+		(DISPLAY="" "\${HERE}/controlPanel.sh" ${WINE_EXE} wineboot) | zenity --progress --title="Wine Bottle update" --text="Updating Wine Bottle..." --pulsate --auto-close --no-cancel
 		echo "======= AppImage Selection run done! ======="
 		exit 0
 		;;


### PR DESCRIPTION
Adds two path variables to the install scripts' generated controlPanel.sh and Logos.sh scripts. This is to address #41. Due to the way $WINE_EXE is used in the script, it was necessary to create a second variable rather than modifying this one. $WINE_EXE is now just the name of the wine binary itself, and the PATH is separated from it entirely. Changing $WINE_EXE to include a path would yield a double path in the name (e.g., /usr/bin/usr/bin/wine64). These path variables are to remain as variables in the launch script for easily modifying the PATH to the binaries themselves.

The LOGOS_WINE_BIN_PATH and LOGOS_WINESERVER_BIN_PATH variables are determined through `awk`, printing all but the last field and preserving the field separators (i.e., `/`). The PATH variables default to using the system wine version through the `which` command.

A possible way to modify or improve this change would be to collapse the PATH and EXE variable into one variable and to collapse the server PATH variable and the wineserver bin name into its own variable. The problem, as mentioned, is that the $WINE_EXE is used in some ways that should not include a path. Thus $WINE_EXE is currently best used for determining if the script is running wine64 or wine32.

Pending review, this change should be ready to merge.