### PR TITLE
Update Logos version to 9.13

### DIFF
--- a/fast_install_AppImageWine_and_Logos.sh
+++ b/fast_install_AppImageWine_and_Logos.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # From https://github.com/ferion11/LogosLinuxInstaller
-export THIS_SCRIPT_VERSION="fast-v2.38"
+export THIS_SCRIPT_VERSION="fast-v2.39"
 
 #=================================================
 # version of Logos from: https://wiki.logos.com/The_Logos_9_Beta_Program
-if [ -z "${LOGOS64_URL}" ]; then export LOGOS64_URL="https://downloads.logoscdn.com/LBS9/Installer/9.11.0.0022/Logos-x64.msi" ; fi
+if [ -z "${LOGOS64_URL}" ]; then export LOGOS64_URL="https://downloads.logoscdn.com/LBS9/Installer/9.13.0.0018/Logos-x64.msi" ; fi
 
 #LOGOS_MVERSION=$(echo "${LOGOS64_URL}" | cut -d/ -f4); export LOGOS_MVERSION
 LOGOS_VERSION="$(echo "${LOGOS64_URL}" | cut -d/ -f6)"; export LOGOS_VERSION


### PR DESCRIPTION
A recent resource update causes Wine to crash when opening ≤9.9. We need to update to 9.13. Unfortunately, this means we will have to deal with the menu bug. See #49.