### PR TITLE
New Logos.sh Option to Circumvent Full Reindexing

### DIFF
--- a/fast_install_AppImageWine_and_Logos.sh
+++ b/fast_install_AppImageWine_and_Logos.sh
@@ -294,12 +294,20 @@ case "\${1}" in
 		exit 0
 		;;
 	"removeAllIndex")
-		echo "======= removing all LogosBible index files only: ======="
+		echo "======= removing all LogosBible index and librarycatalog files: ======="
 		LOGOS_EXE="\$(find "\${WINEPREFIX}" -name Logos.exe | grep "Logos\/Logos.exe")"
 		LOGOS_DIR="\$(dirname "\${LOGOS_EXE}")"
 		rm -fv "\${LOGOS_DIR}"/Data/*/BibleIndex/*
 		rm -fv "\${LOGOS_DIR}"/Data/*/LibraryIndex/*
 		rm -fv "\${LOGOS_DIR}"/Data/*/PersonalBookIndex/*
+		rm -fv "\${LOGOS_DIR}"/Data/*/LibraryCatalog/*
+		echo "======= removing all LogosBible index files done! ======="
+		exit 0
+		;;
+	"removeLibraryCatalog")
+		echo "======= removing LogosBible LibraryCatalog files only: ======="
+		LOGOS_EXE="\$(find "\${WINEPREFIX}" -name Logos.exe | grep "Logos\/Logos.exe")"
+		LOGOS_DIR="\$(dirname "\${LOGOS_EXE}")"
 		rm -fv "\${LOGOS_DIR}"/Data/*/LibraryCatalog/*
 		echo "======= removing all LogosBible index files done! ======="
 		exit 0

--- a/fast_install_AppImageWine_and_Logos.sh
+++ b/fast_install_AppImageWine_and_Logos.sh
@@ -294,7 +294,7 @@ case "\${1}" in
 		exit 0
 		;;
 	"removeAllIndex")
-		echo "======= removing all LogosBible index and librarycatalog files: ======="
+		echo "======= removing all LogosBible BibleIndex, LibraryIbdex, PersonalBookIndex, and LibraryCatalog files: ======="
 		LOGOS_EXE="\$(find "\${WINEPREFIX}" -name Logos.exe | grep "Logos\/Logos.exe")"
 		LOGOS_DIR="\$(dirname "\${LOGOS_EXE}")"
 		rm -fv "\${LOGOS_DIR}"/Data/*/BibleIndex/*


### PR DESCRIPTION
It was discussed in the Telegram group and a member specified that removing the LibraryCatalog files alone prevented the need for a complete reindexing. This change adds an option to Logos.sh to make this easier to do once installed.