### PR TITLE
Add winetricks -q d3dcompiler_47 to install to correct #68.

### DIFF
--- a/install_Logos10_download.sh
+++ b/install_Logos10_download.sh
@@ -768,6 +768,8 @@ if [ -z "${WINETRICKS_UNATTENDED}" ]; then
 	echo "================================================="
 	winetricks_install -q settings win10
 	echo "================================================="
+	winetricks_install -q d3dcompiler_47
+	echo "================================================="
 else
 #	echo "================================================="
 #	winetricks_install -q corefonts
@@ -777,6 +779,8 @@ else
 	winetricks_install -q settings fontsmooth=rgb
 	echo "================================================="
 	winetricks_install -q settings win10
+	echo "================================================="
+	winetricks_install -q d3dcompiler_47
 	echo "================================================="
 fi
 #-------------------------------------------------

--- a/install_Verbum10_download.sh
+++ b/install_Verbum10_download.sh
@@ -768,6 +768,8 @@ if [ -z "${WINETRICKS_UNATTENDED}" ]; then
 	echo "================================================="
 	winetricks_install -q settings win10
 	echo "================================================="
+	winetricks_install -q d3dcompiler_47
+	echo "================================================="
 else
 #	echo "================================================="
 #	winetricks_install -q corefonts
@@ -777,6 +779,8 @@ else
 	winetricks_install -q settings fontsmooth=rgb
 	echo "================================================="
 	winetricks_install -q settings win10
+	echo "================================================="
+	winetricks_install -q d3dcompiler_47
 	echo "================================================="
 fi
 #-------------------------------------------------


### PR DESCRIPTION
Adds winetricks d3dcompiler to the L/V10 scripts.

Should these be added to L/V9, too?