### PR TITLE
Fix Install Breaking During d3dcompiler_47 Install

### DIFF
--- a/Logos10_Setup.sh
+++ b/Logos10_Setup.sh
@@ -824,15 +824,10 @@ winetricks_install() {
 
 	# NOTE: sometimes the process finishes before the wait command, giving the error code 127
 	if [ "${ZENITY_RETURN}" == "0" ] || [ "${ZENITY_RETURN}" == "127" ] ; then
-        if [ "${WINETRICKS_STATUS}" == "141" ] ; then
-            echo "Error installing d3dcompiler_47. Attempting alternative install."
-            WINEPREFIX="$WINEPREFIX" "$WINETRICKSBIN" -q d3dcompiler_47;
-		elif [ "${WINETRICKS_STATUS}" != "0" ] ; then
+		if [ "${WINETRICKS_STATUS}" != "0" ] ; then
 			wineserver -k;
 			echo "ERROR on : winetricks ${*}; WINETRICKS_STATUS: ${WINETRICKS_STATUS}";
 			gtk_fatal_error "The installation was cancelled because of sub-job failure!\n * winetricks ${*}\n  - WINETRICKS_STATUS: ${WINETRICKS_STATUS}";
-		else
-				:
 		fi
 	else
 		wineserver -k;
@@ -842,12 +837,26 @@ winetricks_install() {
 
 	heavy_wineserver_wait;
 }
+
+winetricks_dll_install() {
+    echo "winetricks ${*}"
+    
+	gtk_continue_question "Now the script will install the DLL ${*}. Continue?"
+
+	"$WINETRICKSBIN" "${@}"
+
+    echo "winetricks ${*} DONE!";
+    
+    heavy_wineserver_wait;
+
+}
+
 if [ -z "${WINETRICKS_UNATTENDED}" ]; then
 	winetricks_install -q corefonts
 	winetricks_install -q tahoma
 	winetricks_install -q settings fontsmooth=rgb
 	winetricks_install -q settings win10
-	winetricks_install -q d3dcompiler_47
+	winetricks_dll_install -q d3dcompiler_47;
 else
 	echo "================================================="
 	winetricks_install corefonts
@@ -858,7 +867,7 @@ else
 	echo "================================================="
 	winetricks_install settings win10
 	echo "================================================="
-	winetricks_install d3dcompiler_47
+	winetricks_dll_install d3dcompiler_47
 	echo "================================================="
 fi
 #-------------------------------------------------

--- a/Logos10_Setup.sh
+++ b/Logos10_Setup.sh
@@ -32,7 +32,7 @@ WINE64_APPIMAGE_FILENAME="$(basename "${WINE64_APPIMAGE_URL}")"; export WINE64_A
 # back to Jul 23, 2020 release of winetricks, not more of the last git random broken fun:
 #if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/29d4edcfaec76128a68a0506605fd84473b6e38c/src/winetricks" ; fi
 # trying one customized version of winetricks, of the link above:
-if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks" ; fi
+if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/5904ee355e37dff4a3ab37e1573c56cffe6ce223/src/winetricks" ; fi
 if [ -z "${WINETRICKS_DOWNLOADER+x}" ]; then export WINETRICKS_DOWNLOADER="wget" ; fi
 if [ -z "${WINETRICKS_UNATTENDED+x}" ]; then export WINETRICKS_UNATTENDED="" ; fi
 
@@ -638,7 +638,7 @@ echo "* Script version: ${LOGOS_SCRIPT_VERSION}"
 installationChoice="$(zenity --width=700 --height=310 \
 	--title="Question: Install Logos Bible using script ${LOGOS_SCRIPT_VERSION}" \
 	--text="This script will create one directory in (which can be changed by setting the INSTALLDIR variable):\n\"${INSTALLDIR}\"\nto be an installation of LogosBible v${LOGOS_VERSION} independent of other installations.\nPlease select the type of installation:" \
-	--list --radiolist --column "S" --column "Descrition" \
+	--list --radiolist --column "S" --column "Description" \
 	TRUE "1- Install LogosBible64 using the native Wine64 (default) Which must be 7.18-staging or later. Stable or Devel do not work." \
 	FALSE "2- Install LogosBible64 using Wine64 ${WINE64_APPIMAGE_FULL_VERSION} AppImage." )"
 # FALSE "3- Install LogosBible64 using Wine64 ${WINE64_APPIMAGE_VERSION} plain AppImage without dependencies."
@@ -762,18 +762,46 @@ wine_reg_install "disable-winemenubuilder.reg"
 echo "================================================="
 wine_reg_install "renderer_gdi.reg"
 echo "================================================="
-#-------------------------------------------------
 
-gtk_continue_question "Now the script will install the winetricks packages at ${WINEPREFIX}. Do you wish to continue?"
+downloadWinetricks() {
+	echo "Downloading winetricks from the Internet…"
+	if [ -f "${DOWNLOADED_RESOURCES}/winetricks" ]; then
+		echo "A winetricks binary has already been downloaded. Using it..."
+		cp "${DOWNLOADED_RESOURCES}/winetricks" "${WORKDIR}"
+	else
+		echo "winetricks does not exist. Downloading..."
+		gtk_download "${WINETRICKS_URL}" "${WORKDIR}"
+	fi
+	chmod +x "${WORKDIR}/winetricks"
+}
 
-if [ -f "${DOWNLOADED_RESOURCES}/winetricks" ]; then
-	echo "winetricks exists. Using it..."
-	cp "${DOWNLOADED_RESOURCES}/winetricks" "${WORKDIR}"
+if [ "$(which winetricks)" ]; then
+	winetricksChoice="$(zenity --width=700 --height=310 \
+    --title="Question: Should the script use local winetricks or download winetricks fresh?" \
+    --text="This script needs to set some Wine options that help or make Logos run on Linux. Please select whether to use your local winetricks version or a fresh install." \
+    --list --radiolist --column "S" --column "Description" \
+    TRUE "1- Use local winetricks." \
+    FALSE "2- Download winetricks from the Internet." )"
+
+	case "${winetricksChoice}" in
+    	1*)
+    	    echo "Setting winetricks to the local binary..."
+			if [ -z "${WINETRICKSBIN}" ]; then WINETRICKSBIN="$(which winetricks)"; fi
+    	    ;;
+    	2*)
+			downloadWinetricks;
+			if [ -z "${WINETRICKSBIN}" ]; then WINETRICKSBIN="${WORKDIR}/winetricks"; fi
+    	    ;;
+    	*)
+    	    gtk_fatal_error "Installation canceled!"
+	esac
 else
-	echo "winetricks does not exist. Downloading..."
-	gtk_download "${WINETRICKS_URL}" "${WORKDIR}"
+	echo "Local winetricks not found. Downloading winetricks from the Internet…"
+	downloadWinetricks;
+	export WINETRICKSBIN="${WORKDIR}/winetricks"
 fi
-chmod +x "${WORKDIR}/winetricks"
+
+echo "Winetricks is ready to be used."
 
 #-------------------------------------------------
 winetricks_install() {
@@ -786,48 +814,51 @@ winetricks_install() {
 	zenity --progress --title="Winetricks ${*}" --text="Winetricks installing ${*}" --pulsate --auto-close < "${pipe_winetricks}" &
 	ZENITY_PID="${!}"
 
-	#"${WORKDIR}"/winetricks "${@}" > "${pipe_winetricks}"
-	"${WORKDIR}"/winetricks "${@}" | tee "${pipe_winetricks}"
-	WINETRICKS_STATUS="${?}"
+	"$WINETRICKSBIN" "${@}" | tee "${pipe_winetricks}";
+	WINETRICKS_STATUS="${?}";
 
-	wait "${ZENITY_PID}"
-	ZENITY_RETURN="${?}"
+	wait "${ZENITY_PID}";
+	ZENITY_RETURN="${?}";
 
-	#fuser -TERM -k -w "${pipe_winetricks}"
-	rm -rf "${pipe_winetricks}"
+	rm -rf "${pipe_winetricks}";
 
 	# NOTE: sometimes the process finishes before the wait command, giving the error code 127
 	if [ "${ZENITY_RETURN}" == "0" ] || [ "${ZENITY_RETURN}" == "127" ] ; then
-		if [ "${WINETRICKS_STATUS}" != "0" ] ; then
-			wineserver -k
-			echo "ERROR on : winetricks ${*}; WINETRICKS_STATUS: ${WINETRICKS_STATUS}"
-			gtk_fatal_error "The installation was cancelled because of sub-job failure!\n * winetricks ${*}\n  - WINETRICKS_STATUS: ${WINETRICKS_STATUS}"
+        if [ "${WINETRICKS_STATUS}" == "141" ] ; then
+            echo "Error installing d3dcompiler_47. Attempting alternative install."
+            WINEPREFIX="$WINEPREFIX" "$WINETRICKSBIN" -q d3dcompiler_47;
+		elif [ "${WINETRICKS_STATUS}" != "0" ] ; then
+			wineserver -k;
+			echo "ERROR on : winetricks ${*}; WINETRICKS_STATUS: ${WINETRICKS_STATUS}";
+			gtk_fatal_error "The installation was cancelled because of sub-job failure!\n * winetricks ${*}\n  - WINETRICKS_STATUS: ${WINETRICKS_STATUS}";
+		else
+				:
 		fi
 	else
-		wineserver -k
-		gtk_fatal_error "The installation was cancelled!\n * ZENITY_RETURN: ${ZENITY_RETURN}"
+		wineserver -k;
+		gtk_fatal_error "The installation was cancelled!\n * ZENITY_RETURN: ${ZENITY_RETURN}";
 	fi
-	echo "winetricks ${*} DONE!"
+	echo "winetricks ${*} DONE!";
 
-	heavy_wineserver_wait
+	heavy_wineserver_wait;
 }
 if [ -z "${WINETRICKS_UNATTENDED}" ]; then
 	winetricks_install -q corefonts
 	winetricks_install -q tahoma
-	winetricks_install -q d3dcompiler_47
 	winetricks_install -q settings fontsmooth=rgb
 	winetricks_install -q settings win10
+	winetricks_install -q d3dcompiler_47
 else
 	echo "================================================="
 	winetricks_install corefonts
 	echo "================================================="
 	winetricks_install tahoma
 	echo "================================================="
-	winetricks_install d3dcompiler_47
-	echo "================================================="
 	winetricks_install settings fontsmooth=rgb
 	echo "================================================="
 	winetricks_install settings win10
+	echo "================================================="
+	winetricks_install d3dcompiler_47
 	echo "================================================="
 fi
 #-------------------------------------------------

--- a/Logos10_Setup.sh
+++ b/Logos10_Setup.sh
@@ -32,7 +32,7 @@ WINE64_APPIMAGE_FILENAME="$(basename "${WINE64_APPIMAGE_URL}")"; export WINE64_A
 # back to Jul 23, 2020 release of winetricks, not more of the last git random broken fun:
 #if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/29d4edcfaec76128a68a0506605fd84473b6e38c/src/winetricks" ; fi
 # trying one customized version of winetricks, of the link above:
-if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://github.com/ferion11/libsutil/releases/download/winetricks/winetricks" ; fi
+if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks" ; fi
 if [ -z "${WINETRICKS_DOWNLOADER+x}" ]; then export WINETRICKS_DOWNLOADER="wget" ; fi
 if [ -z "${WINETRICKS_UNATTENDED+x}" ]; then export WINETRICKS_UNATTENDED="" ; fi
 

--- a/Verbum10_Setup.sh
+++ b/Verbum10_Setup.sh
@@ -762,18 +762,46 @@ wine_reg_install "disable-winemenubuilder.reg"
 echo "================================================="
 wine_reg_install "renderer_gdi.reg"
 echo "================================================="
-#-------------------------------------------------
 
-gtk_continue_question "Now the script will install the winetricks packages at ${WINEPREFIX}. Do you wish to continue?"
+downloadWinetricks() {
+	echo "Downloading winetricks from the Internet…"
+	if [ -f "${DOWNLOADED_RESOURCES}/winetricks" ]; then
+		echo "A winetricks binary has already been downloaded. Using it..."
+		cp "${DOWNLOADED_RESOURCES}/winetricks" "${WORKDIR}"
+	else
+		echo "winetricks does not exist. Downloading..."
+		gtk_download "${WINETRICKS_URL}" "${WORKDIR}"
+	fi
+	chmod +x "${WORKDIR}/winetricks"
+}
 
-if [ -f "${DOWNLOADED_RESOURCES}/winetricks" ]; then
-	echo "winetricks exists. Using it..."
-	cp "${DOWNLOADED_RESOURCES}/winetricks" "${WORKDIR}"
+if [ "$(which winetricks)" ]; then
+	winetricksChoice="$(zenity --width=700 --height=310 \
+    --title="Question: Should the script use local winetricks or download winetricks fresh?" \
+    --text="This script needs to set some Wine options that help or make Verbum run on Linux. Please select whether to use your local winetricks version or a fresh install." \
+    --list --radiolist --column "S" --column "Description" \
+    TRUE "1- Use local winetricks." \
+    FALSE "2- Download winetricks from the Internet." )"
+
+	case "${winetricksChoice}" in
+    	1*)
+    	    echo "Setting winetricks to the local binary..."
+			if [ -z "${WINETRICKSBIN}" ]; then WINETRICKSBIN="$(which winetricks)"; fi
+    	    ;;
+    	2*)
+			downloadWinetricks;
+			if [ -z "${WINETRICKSBIN}" ]; then WINETRICKSBIN="${WORKDIR}/winetricks"; fi
+    	    ;;
+    	*)
+    	    gtk_fatal_error "Installation canceled!"
+	esac
 else
-	echo "winetricks does not exist. Downloading..."
-	gtk_download "${WINETRICKS_URL}" "${WORKDIR}"
+	echo "Local winetricks not found. Downloading winetricks from the Internet…"
+	downloadWinetricks;
+	export WINETRICKSBIN="${WORKDIR}/winetricks"
 fi
-chmod +x "${WORKDIR}/winetricks"
+
+echo "Winetricks is ready to be used."
 
 #-------------------------------------------------
 winetricks_install() {
@@ -786,48 +814,51 @@ winetricks_install() {
 	zenity --progress --title="Winetricks ${*}" --text="Winetricks installing ${*}" --pulsate --auto-close < "${pipe_winetricks}" &
 	ZENITY_PID="${!}"
 
-	#"${WORKDIR}"/winetricks "${@}" > "${pipe_winetricks}"
-	"${WORKDIR}"/winetricks "${@}" | tee "${pipe_winetricks}"
-	WINETRICKS_STATUS="${?}"
+	"$WINETRICKSBIN" "${@}" | tee "${pipe_winetricks}";
+	WINETRICKS_STATUS="${?}";
 
-	wait "${ZENITY_PID}"
-	ZENITY_RETURN="${?}"
+	wait "${ZENITY_PID}";
+	ZENITY_RETURN="${?}";
 
-	#fuser -TERM -k -w "${pipe_winetricks}"
-	rm -rf "${pipe_winetricks}"
+	rm -rf "${pipe_winetricks}";
 
 	# NOTE: sometimes the process finishes before the wait command, giving the error code 127
 	if [ "${ZENITY_RETURN}" == "0" ] || [ "${ZENITY_RETURN}" == "127" ] ; then
-		if [ "${WINETRICKS_STATUS}" != "0" ] ; then
-			wineserver -k
-			echo "ERROR on : winetricks ${*}; WINETRICKS_STATUS: ${WINETRICKS_STATUS}"
-			gtk_fatal_error "The installation was cancelled because of sub-job failure!\n * winetricks ${*}\n  - WINETRICKS_STATUS: ${WINETRICKS_STATUS}"
+        if [ "${WINETRICKS_STATUS}" == "141" ] ; then
+            echo "Error installing d3dcompiler_47. Attempting alternative install."
+            WINEPREFIX="$WINEPREFIX" "$WINETRICKSBIN" -q d3dcompiler_47;
+		elif [ "${WINETRICKS_STATUS}" != "0" ] ; then
+			wineserver -k;
+			echo "ERROR on : winetricks ${*}; WINETRICKS_STATUS: ${WINETRICKS_STATUS}";
+			gtk_fatal_error "The installation was cancelled because of sub-job failure!\n * winetricks ${*}\n  - WINETRICKS_STATUS: ${WINETRICKS_STATUS}";
+		else
+				:
 		fi
 	else
-		wineserver -k
-		gtk_fatal_error "The installation was cancelled!\n * ZENITY_RETURN: ${ZENITY_RETURN}"
+		wineserver -k;
+		gtk_fatal_error "The installation was cancelled!\n * ZENITY_RETURN: ${ZENITY_RETURN}";
 	fi
-	echo "winetricks ${*} DONE!"
+	echo "winetricks ${*} DONE!";
 
-	heavy_wineserver_wait
+	heavy_wineserver_wait;
 }
 if [ -z "${WINETRICKS_UNATTENDED}" ]; then
-    winetricks_install -q corefonts
-    winetricks_install -q tahoma
-    winetricks_install -q d3dcompiler_47
-    winetricks_install -q settings fontsmooth=rgb
-    winetricks_install -q settings win10
+	winetricks_install -q corefonts
+	winetricks_install -q tahoma
+	winetricks_install -q settings fontsmooth=rgb
+	winetricks_install -q settings win10
+	winetricks_install -q d3dcompiler_47
 else
 	echo "================================================="
 	winetricks_install corefonts
 	echo "================================================="
 	winetricks_install tahoma
 	echo "================================================="
-	winetricks_install d3dcompiler_47
-	echo "================================================="
 	winetricks_install settings fontsmooth=rgb
 	echo "================================================="
 	winetricks_install settings win10
+	echo "================================================="
+	winetricks_install d3dcompiler_47
 	echo "================================================="
 fi
 #-------------------------------------------------

--- a/Verbum10_Setup.sh
+++ b/Verbum10_Setup.sh
@@ -32,7 +32,7 @@ WINE64_APPIMAGE_FILENAME="$(basename "${WINE64_APPIMAGE_URL}")"; export WINE64_A
 # back to Jul 23, 2020 release of winetricks, not more of the last git random broken fun:
 #if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/29d4edcfaec76128a68a0506605fd84473b6e38c/src/winetricks" ; fi
 # trying one customized version of winetricks, of the link above:
-if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://github.com/ferion11/libsutil/releases/download/winetricks/winetricks" ; fi
+if [ -z "${WINETRICKS_URL}" ]; then export WINETRICKS_URL="https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks" ; fi
 if [ -z "${WINETRICKS_DOWNLOADER+x}" ]; then export WINETRICKS_DOWNLOADER="wget" ; fi
 if [ -z "${WINETRICKS_UNATTENDED+x}" ]; then export WINETRICKS_UNATTENDED="" ; fi
 


### PR DESCRIPTION
This hack is a partial fix for #71 and resolves #76. This PR does three things:

- Changes the winetricks URL from ferion11's stored version in his repo to a version from the winetricks repo. This brings two years of script updates without setting the URL to whatever is the latest release.
- Creates a function and zenity question to choose either a system winetricks version determined by `which` or to download the script's stored version.
- Adds an error catch for `WINETRICKS_STATUS=141`, and then attempts to run a winetricks install again, specifying the WINEPREFIX, WINETRICKSBIN, and the DLL.

The error code `141` is a SIGPIPE error that breaks at line 817:

```
"$WINETRICKSBIN" "${@}" | tee "${pipe_winetricks}";
```

However winetricks writes the install for the DLL to the pipe causes the pipe to break.