### PR TITLE
Add `-c|--config` optarg.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+* 10.1.0.0056-v4
+  - Change in numbering scheme to note if Logos was updated or the script
+  - Fix #116.
+  - Added `-c|--config`.
+  - Added `-F|--skip-fonts`.
 * v10.0-4
   - [T. H. Wright]
     - Fix #36.

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -47,6 +47,7 @@ Options:
 						Optionally can accept a config file provided by
 						the user.
                         setting variables.
+    -F   --skip-fonts   Skips installing corefonts and tahoma.
     -f   --force-root   Sets LOGOS_FORCE_ROOT to true, which permits
                         the root user to run the script.
 EOF
@@ -64,12 +65,13 @@ do
         --help)      set -- "$@" -h ;;
         --version)   set -- "$@" -V ;;
 		--config)    set -- "$@" -c ;;
+		--skip-fonts) set -- "$@" -F ;;
 		--force-root) set -- "$@" -f ;;
 		--debug)     set -- "$@" -D ;;
         *)           set -- "$@" "$arg" ;;
     esac
 done
-OPTSTRING=':hvDcf' # Available options
+OPTSTRING=':hvDcFf' # Available options
 
 # First loop: set variable options which may affect other options
 while getopts "$OPTSTRING" opt; do
@@ -98,6 +100,7 @@ while getopts "$OPTSTRING" opt; do
 				echo "No config file found."
 			fi
 			;;
+		F)  export SKIP_FONTS="1" ;;
 		f)	export LOGOS_FORCE_ROOT="1"; ;;
 		D)	export DEBUG=true;
 			WINEDEBUG=""; ;;
@@ -1301,12 +1304,16 @@ installMSI() {
 
 installFonts() {
 	if [ -z "${WINETRICKS_UNATTENDED}" ]; then
-		winetricks_install -q corefonts
-		winetricks_install -q tahoma
+		if [ -z "${SKIP_FONTS}" ]; then
+			winetricks_install -q corefonts
+			winetricks_install -q tahoma
+		fi
 		winetricks_install -q settings fontsmooth=rgb
 	else
-		winetricks_install corefonts
-		winetricks_install tahoma
+		if [ -z "${SKIP_FONTS}" ]; then
+			winetricks_install corefonts
+			winetricks_install tahoma
+		fi
 		winetricks_install settings fontsmooth=rgb
 	fi
 }


### PR DESCRIPTION
This new optarg lets us store a set of configs that can be reused either in future installs/reinstalls or for use by the generated Logos.sh and controlPanel.sh scripts. An example of how this can be handy is for backups and restores (See #110). It closes #116.

This script needs testing.

- [x] Does the script successfully install when no config file is supplied
- [x] When no config file is supplied, does the installer generate a config file when told to do so?
- [x] Does the script use a supplied config file's variables and bypass the installer prompts?

To test the config file, the format is a set of bash options. The following is the template in the script. It may be beneficial to have this autogenerated and then modify it later, unless you know what values should be for the script to complete.

```
# INSTALL OPTIONS
FLPRODUCT="${FLPRODUCT}"
FLPRODUCTi="${FLPRODUCTi}"
TARGETVERSION="${TARGETVERSION}"
INSTALLDIR="${INSTALLDIR}"
APPDIR="${APPDIR}"
APPDIR_BINDIR="${APPDIR_BINDIR}"
WINETRICKSBIN="${WINETRICKSBIN}"
WINEPREFIX="${WINEPREFIX}"
WINEBIN_CODE="${WINEBIN_CODE}"
WINE_EXE="${WINE_EXE}"
WINESERVER_EXE="${WINESERVER_EXE}"
WINE64_APPIMAGE_FULL_URL="${WINE64_APPIMAGE_FULL_URL}"
WINE64_APPIMAGE_FULL_FILENAME="${WINE64_APPIMAGE_FULL_FILENAME}"
LOGOS_EXECUTABLE="${LOGOS_EXECUTABLE}"

# RESTORE OPTIONS
BACKUPDIR=""
```