### PR TITLE
Fix #68.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
-* 10.1.0.0056-v4
-  - Change in numbering scheme to note if Logos was updated or the script
-  - Fix #116.
-  - Added `-c|--config`.
-  - Added `-F|--skip-fonts`.
+* 10.1.0.0056-v5.1
+  - [T. H. Wright]
+    - Fix #68.
+* 10.1.0.0056-v5
+  - [T. H. Wright]
+    - Change in numbering scheme to note if Logos was updated or the script
+    - Fix #116.
+    - Added `-c|--config`.
+    - Added `-F|--skip-fonts`.
 * v10.0-4
   - [T. H. Wright]
     - Fix #36.

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -811,7 +811,6 @@ make_skel() {
 
 ## BEGIN CHECK DEPENDENCIES FUNCTIONS
 check_commands() {
-	#TODO: Check all commands before erroring out. See #113. Use array?
     for cmd in "$@"; do
         if have_dep "${cmd}"; then
             echo "* command ${cmd} is installed!"
@@ -1327,15 +1326,21 @@ installFonts() {
 	fi
 }
 
+installD3DCompiler() {
+	if [ -z "${WINETRICKS_UNATTENDED}" ]; then
+		winetricks_dll_install -q d3dcompiler_47;
+	else
+		winetricks_dll_install d3dcompiler_47;
+	fi
+}
+
 installLogos9() {	
 	getPremadeWineBottle;
 
 	setWineTricks;
-
-	installFonts
-
+	installFonts;
+	installD3DCompiler;
 	getLogosExecutable;
-
 	installMSI;
 
 	echo "======= Set ${FLPRODUCT}Bible Indexing to Vista Mode: ======="
@@ -1365,20 +1370,16 @@ EOF
 	wine_reg_install "renderer_gdi.reg";
 
 	setWinetricks;
-
 	installFonts;
+	installD3DCompiler;
 
 	if [ -z "${WINETRICKS_UNATTENDED}" ]; then
 		winetricks_install -q settings win10
-		#TODO: Verify if d3dcompiler_47 helps Logos 9. See #68. If so, this should be added to Logos 9's install procedure.
-		winetricks_dll_install -q d3dcompiler_47;
 	else
 		winetricks_install settings win10
-		winetricks_dll_install d3dcompiler_47
 	fi
 
 	getLogosExecutable;
-
 	installMSI;
 }
 ## END LOGOS INSTALL FUNCTIONS


### PR DESCRIPTION
While the fix has been implemented for Logos 10 for sometime, that change was not ported to Logos 9 for lack of testing. This PR seeks to resolve that finally.

Simple change to make the Logos 9 install routine install the d3dcompiler DLL.

WIP: Testing with a brand new Logos 9 install, downloaded and indexing. All I should need is a single right click on the other side.