### PR TITLE
Remove git commit strings from wine binary version check

### DIFF
--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -460,7 +460,7 @@ wineBinaryVersionCheck() {
 
 	# Check if the binary is executable, of if TESTBINARY's version is ≥ WINE_MINIMUM, or if it is Proton, else remove.
 	if [ -x "${TESTBINARY}" ]; then
-		TESTWINEVERSION=$("$TESTBINARY" --version | awk -F' ' '{print $1}' | awk -F'-' '{print $2}');
+		TESTWINEVERSION=$("$TESTBINARY" --version | awk -F' ' '{print $1}' | awk -F'-' '{print $2}' | awk -F'.' '{print $1"."$2}');
 		if (( $(echo "$TESTWINEVERSION >= $WINE_MINIMUM" | bc -l) )); then
 			return 0;
 		elif [[ ${TESTBINARY} =~ .*"Proton - Experimental".* ]]; then


### PR DESCRIPTION
Some rolling release distributions include commit strings in their binary versions. `wineBinaryVersionCheck()` does not account for this in its current version comparison. This commit strips the commit string from the version when checking it.

This should have no effect on the Proton check as that checks the binary's path, not its version.