### PR TITLE
Retrieve Logos Release Version from XML Feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
-* 3.6.1
+* 3.6.2
   - Retrieve Logos release version from XML feed [T. H. Wright]
   - Modify the script version, and update the CHANGELOG to reflect this change.
-* 3.6
+* 3.6.1
+  - Introduce logos_error() to simplify error messages. [T. H. Wright]
+* 3.6.0
   - [T. H. Wright]
     - Move generated scripts to separate files: `Launcher-Template.sh`, `controlPanel-Template.sh`.
     - Moved generated scripts case statements to optargs (e.g., `-i|--indexing`). Fix #108.
@@ -15,13 +17,13 @@
 * 3.5.1
   - [T. H. Wright]
     - Fix #68.
-* 3.5
+* 3.5.0
   - [T. H. Wright]
     - Change in numbering scheme to note if Logos was updated or the script
     - Fix #116.
     - Added `-c|--config`.
     - Added `-F|--skip-fonts`.
-* 3.4
+* 3.4.0
   - [T. H. Wright]
     - Fix #36.
     - Fix #81.
@@ -34,19 +36,19 @@
     - Fix #112.
     - Added `-f|--force-root`.
     - Added `-D|--debug`.
-* 3.3
+* 3.3.0
   - [T. H. Wright]
     - Fix #93.
-* 3.2
+* 3.2.0
   - [T. H. Wright]
     - Fix #92.
-* 3.1
+* 3.1.0
   - Install DLL d3dcompiler_47 (jg00dman, thw26)
   - L10: Change winetricks URL
   - L10: allow using local winetricks (thw26)
   - L10: add winetricks_dll_install (thw26)
   - Add basic optargs: `-h|--help` and `-v|--version` (thw26)
-* 3.0:
+* 3.0.0:
   - Refactoring and renaming of scripts, updates to README, by T. H. Wright (thw26)
   - Logos 10 and Verbum 10 install scripts by John Goodman (jg00dman)
     - NOTE: Scripts are now numbered by Logos version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-* 10.1.0.0056-v6
+* 3.6.1
+  - Retrieve Logos release version from XML feed [T. H. Wright]
+  - Modify the script version, and update the CHANGELOG to reflect this change.
+* 3.6
   - [T. H. Wright]
     - Move generated scripts to separate files: `Launcher-Template.sh`, `controlPanel-Template.sh`.
     - Moved generated scripts case statements to optargs (e.g., `-i|--indexing`). Fix #108.
@@ -9,16 +12,16 @@
     - Added `-r|--regenerate-scripts`.
     - Added LOGOS.sh: `-R|--check-resources`. Requires `sysstat` and `psrecord`.
     - Fix #129.
-* 10.1.0.0056-v5.1
+* 3.5.1
   - [T. H. Wright]
     - Fix #68.
-* 10.1.0.0056-v5
+* 3.5
   - [T. H. Wright]
     - Change in numbering scheme to note if Logos was updated or the script
     - Fix #116.
     - Added `-c|--config`.
     - Added `-F|--skip-fonts`.
-* v10.0-4
+* 3.4
   - [T. H. Wright]
     - Fix #36.
     - Fix #81.
@@ -31,19 +34,19 @@
     - Fix #112.
     - Added `-f|--force-root`.
     - Added `-D|--debug`.
-* v10.0-3
+* 3.3
   - [T. H. Wright]
     - Fix #93.
-* v10.0-2
+* 3.2
   - [T. H. Wright]
     - Fix #92.
-* v10.0-1
+* 3.1
   - Install DLL d3dcompiler_47 (jg00dman, thw26)
   - L10: Change winetricks URL
   - L10: allow using local winetricks (thw26)
   - L10: add winetricks_dll_install (thw26)
   - Add basic optargs: `-h|--help` and `-v|--version` (thw26)
-* v10.0:
+* 3.0:
   - Refactoring and renaming of scripts, updates to README, by T. H. Wright (thw26)
   - Logos 10 and Verbum 10 install scripts by John Goodman (jg00dman)
     - NOTE: Scripts are now numbered by Logos version.

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # shellcheck disable=SC2317
-LOGOS_RELEASE_VERSION="23.1.0.0033"
-LOGOS_SCRIPT_TITLE="Logos Linux Installer" # From https://github.com/ferion11/LogosLinuxInstaller
+export LOGOS_SCRIPT_TITLE="Logos Linux Installer" # From https://github.com/ferion11/LogosLinuxInstaller
 export LOGOS_SCRIPT_AUTHOR="Ferion11, John Goodman, T. H. Wright"
-export LOGOS_SCRIPT_VERSION="${LOGOS_RELEASE_VERSION}-v6" # Script version to match FaithLife Product version.
+export LOGOS_SCRIPT_VERSION="3.6.1" # Script version to match FaithLife Product version.
 
 #####
 # Originally written by Ferion11.
@@ -350,7 +349,7 @@ checkDependencies() {
 		exit 1
 	fi
 
-	check_commands mktemp patch lsof wget find sed grep ntlm_auth awk tr;
+	check_commands mktemp patch lsof wget find sed grep ntlm_auth awk tr bc xmllint;
 }
 
 checkDependenciesLogos10() {
@@ -416,12 +415,10 @@ chooseVersion() {
 		*"10")
 			checkDependenciesLogos10;
 			export TARGETVERSION="10";
-			if [ -z "${LOGOS64_URL}" ]; then export LOGOS64_URL="https://downloads.logoscdn.com/LBS10/${VERBUM_PATH}Installer/${LOGOS_RELEASE_VERSION}/${FLPRODUCT}-x64.msi" ; fi
 			;;
 		*"9")
 			checkDependenciesLogos9;
 			export TARGETVERSION="9";
-			if [ -z "${LOGOS64_URL}" ]; then export LOGOS64_URL="https://downloads.logoscdn.com/LBS9/${VERBUM_PATH}Installer/9.17.0.0010/${FLPRODUCT}-x64.msi" ; fi
 			;;
 		"Exit.")
 			exit
@@ -429,6 +426,9 @@ chooseVersion() {
 		*)
 			logos_error "Installation canceled!"
 	esac
+
+	LOGOS_RELEASE_VERSION=$(curl -s "https://clientservices.logos.com/update/v1/feed/logos${TARGETVERSION}/stable.xml" | xmllint --format - | sed -e 's/ xmlns.*=".*"//g' | sed -e 's@logos:minimum-os-version@minimum-os-version@g' | sed -e 's@logos:version@version@g' | xmllint --xpath "/feed/entry[1]/version/text()" -); export LOGOS_RELEASE_VERSION;
+	if [ -z "${LOGOS64_URL}" ]; then export LOGOS64_URL="https://downloads.logoscdn.com/LBS${TARGETVERSION}/${VERBUM_PATH}Installer/${LOGOS_RELEASE_VERSION}/${FLPRODUCT}-x64.msi" ; fi
 
 	if [ "${FLPRODUCT}" = "Logos" ]; then
 		LOGOS_VERSION="$(echo "${LOGOS64_URL}" | cut -d/ -f6)"; 

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2317
 export LOGOS_SCRIPT_TITLE="Logos Linux Installer" # From https://github.com/ferion11/LogosLinuxInstaller
 export LOGOS_SCRIPT_AUTHOR="Ferion11, John Goodman, T. H. Wright"
-export LOGOS_SCRIPT_VERSION="3.6.3" # Script version to match FaithLife Product version.
+export LOGOS_SCRIPT_VERSION="3.6.3" # Script version for this Installer Script
 
 #####
 # Originally written by Ferion11.

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2317
 export LOGOS_SCRIPT_TITLE="Logos Linux Installer" # From https://github.com/ferion11/LogosLinuxInstaller
 export LOGOS_SCRIPT_AUTHOR="Ferion11, John Goodman, T. H. Wright"
-export LOGOS_SCRIPT_VERSION="3.6.1" # Script version to match FaithLife Product version.
+export LOGOS_SCRIPT_VERSION="3.6.3" # Script version to match FaithLife Product version.
 
 #####
 # Originally written by Ferion11.


### PR DESCRIPTION
Pulls the Logos release version from the Logos release XML feed.

Changes the version info of the release from a combination of Logos release and script update to the script version, here indicated as the third major revision of the script, the sixth improvement to that revision, and the first bug fix.

I consider this change to be a patch, not a new minor version.