### PR TITLE
Error messages

### DIFF
--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -261,6 +261,16 @@ wait_process_using_dir() {
 	echo "---------------------"
 }
 
+cli_error() {
+	echo "${1}"
+}
+
+logos_error() {
+	ERROR_MESSAGE="${1}"
+	cli_error="${ERROR_MESSAGE}"
+	gtk_fatal_error ${ERROR_MESSAGE};
+}
+
 make_skel() {
 # ${1} - SET_APPIMAGE_FILENAME
 	export SET_APPIMAGE_FILENAME="${1}"
@@ -738,7 +748,7 @@ winetricks_install() {
 
 	# zenity GUI feedback
 	zenity --progress --title="Winetricks ${*}" --text="Winetricks installing ${*}" --pulsate --auto-close < "${pipe_winetricks}" &
-	ZENITY_PID="${!}"
+	ZENITY_PID="${!}";
 
 	"$WINETRICKSBIN" "${@}" | tee "${pipe_winetricks}";
 	WINETRICKS_STATUS="${?}";

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -104,7 +104,7 @@ gtk_error() {
 }
 
 cli_error() {
-    echo "${1}"
+    printf "%s\n" "${1}"
 }
 
 logos_error() {

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -458,7 +458,7 @@ wineBinaryVersionCheck() {
 		#gtk_fatal_error "TARGETVERSION not set."
 	fi
 
-	# Check if the binary is executable, of if TESTBINARY's version is ≥ WINE_MINIMUM, or if it is Proton, else remove.
+	# Check if the binary is executable. If so, check if TESTBINARY's version is ≥ WINE_MINIMUM, or if it is Proton or a link to a Proton binary, else remove.
 	if [ -x "${TESTBINARY}" ]; then
 		TESTWINEVERSION=$("$TESTBINARY" --version | awk -F' ' '{print $1}' | awk -F'-' '{print $2}' | awk -F'.' '{print $1"."$2}');
 		if (( $(echo "$TESTWINEVERSION >= $WINE_MINIMUM" | bc -l) )); then

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -102,12 +102,6 @@ gtk_warn() {
 gtk_error() {
 	zenity --error --width=300 --height=200 --text="$*" --title='Error!'
 }
-gtk_fatal_error() {
-	gtk_error "$@"
-	echo "End in failure!"
-	kill -SIGKILL "-$(($(ps -o pgid= -p "${$}")))"
-	exit 1
-}
 
 cli_error() {
     echo "${1}"
@@ -116,7 +110,9 @@ cli_error() {
 logos_error() {
     ERROR_MESSAGE="${1}"
     cli_error="${ERROR_MESSAGE}"
-    gtk_fatal_error ${ERROR_MESSAGE};
+    gtk_error ${ERROR_MESSAGE};
+	kill -SIGKILL "-$(($(ps -o pgid= -p "${$}")))"
+	exit 1;
 }
 
 mkdir_critical() {

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -108,9 +108,13 @@ cli_error() {
 }
 
 logos_error() {
+	WIKI_LINK="https://github.com/ferion11/LogosLinuxInstaller/wiki"
+	TELEGRAM_LINK="https://t.me/linux_logos"
+	MATRIX_LINK="https://matrix.to/#/#logosbible:matrix.org"
     ERROR_MESSAGE="${1}"
-    cli_error="${ERROR_MESSAGE}"
-    gtk_error ${ERROR_MESSAGE};
+	HELP_MESSAGE="If you need help, please consult:\n\n${WIKI_LINK}\n${TELEGRAM_LINK}\n${MATRIX_LINK}"
+    cli_error "${ERROR_MESSAGE}\n\n${HELP_MESSAGE}";
+    gtk_error "${ERROR_MESSAGE}\n\n${HELP_MESSAGE}";
 	kill -SIGKILL "-$(($(ps -o pgid= -p "${$}")))"
 	exit 1;
 }
@@ -646,7 +650,7 @@ beginInstall() {
 		if [ -x "$(dirname "${WINE_EXE}")/wineserver" ]; then
 			WINESERVER_EXE="$(echo "$(dirname "${WINE_EXE}")/wineserver" | tr -d '\n')"; export WINESERVER_EXE;
 		else
-			logos_error "$(dirname ${WINE_EXE})/wineserver not found. Please either add it or create a symlink to it, and rerun."
+			logos_error "$(dirname "${WINE_EXE}")/wineserver not found. Please either add it or create a symlink to it, and rerun."
 		fi
 	fi
 }


### PR DESCRIPTION
This simplifies our error handling. It moves some things around, removes some lines, but the main thing it does it create a new function:

```
logos_error() {
    WIKI_LINK="https://github.com/ferion11/LogosLinuxInstaller/wiki"
    TELEGRAM_LINK="https://t.me/linux_logos"
    MATRIX_LINK="https://matrix.to/#/#logosbible:matrix.org"
    ERROR_MESSAGE="${1}"
    HELP_MESSAGE="If you need help, please consult:\n\n${WIKI_LINK}\n${TELEGRAM_LINK}\n${MATRIX_LINK}"
    cli_error "${ERROR_MESSAGE}\n\n${HELP_MESSAGE}";
    gtk_error "${ERROR_MESSAGE}\n\n${HELP_MESSAGE}";
    kill -SIGKILL "-$(($(ps -o pgid= -p "${$}")))"
    exit 1;
}
```

When the script errors, it will now deliver an error message to the CLI and through Zenity, as well as display a help message.

This will make #104 and #136 easier.