### PR TITLE
Fix AppImage Installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+* 3.7.2
+  - Fix #178.
+  - Make AppImage default install.
+  - Add options to `-D|--debug`.
 * 3.7.1
   - Add installer `-V|--verbose`. Fix #165. [T. H. Wright]
   - Add installer `-k|--make_skel` and `-b|--custom-binary-path`. Resolve TODOs. Fix #166. [T. H. Wright]

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -741,10 +741,8 @@ chooseInstallMethod() {
 		if [[ "${DIALOG}" == "whiptail" ]] || [[ "${DIALOG}" == "dialog" ]]; then
 			installationChoice=$( $DIALOG --backtitle "${BACKTITLE}" --title "${TITLE}" --radiolist "${QUESTION_TEXT}" 0 0 "${WINEBIN_OPTIONS_LENGTH}" "${WINEBIN_OPTIONS[@]}" 3>&1 1>&2 2>&3 3>&- )
 			read -r -a installArray <<< "${installationChoice}"
-			WINEBIN_CODE=$(echo "${installArray[0]}" | awk -F' ' '{print $1}')
-			WINE_EXE=$(echo "${installArray[0]}" | awk -F' ' '{print $2}')
-			export WINEBIN_CODE;
-			export WINE_EXE;
+			export WINEBIN_CODE=$(echo "${installArray[0]}" | awk -F' ' '{print $1}')
+			export WINE_EXE=$(echo "${installArray[1]}" | awk -F' ' '{print $2}')
 		elif [[ "${DIALOG}" == "zenity" ]]; then
 			column_names=(--column "Choice" --column "Code" --column "Description" --column "Path")
 			installationChoice=$(zenity --width=1024 --height=480 \
@@ -762,7 +760,7 @@ chooseInstallMethod() {
 			logos_error "No dialog tool found."
 		fi
 	fi
-	verbose && echo "${WINE_EXE}"
+	verbose && echo "chooseInstallMethod(): WINEBIN_CODE: ${WINEBIN_CODE}; WINE_EXE: ${WINE_EXE}"
 }
 
 checkExistingInstall() {
@@ -807,6 +805,7 @@ beginInstall() {
 					# Geting the AppImage:
 					getAppImage;	
 					chmod +x "${APPDIR_BINDIR}/${WINE64_APPIMAGE_FULL_FILENAME}"
+					export WINE_EXE="${APPDIR_BINDIR}/wine64"
 				fi
 				;;
 			*)

--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -741,8 +741,8 @@ chooseInstallMethod() {
 		if [[ "${DIALOG}" == "whiptail" ]] || [[ "${DIALOG}" == "dialog" ]]; then
 			installationChoice=$( $DIALOG --backtitle "${BACKTITLE}" --title "${TITLE}" --radiolist "${QUESTION_TEXT}" 0 0 "${WINEBIN_OPTIONS_LENGTH}" "${WINEBIN_OPTIONS[@]}" 3>&1 1>&2 2>&3 3>&- )
 			read -r -a installArray <<< "${installationChoice}"
-			export WINEBIN_CODE=$(echo "${installArray[0]}" | awk -F' ' '{print $1}')
-			export WINE_EXE=$(echo "${installArray[1]}" | awk -F' ' '{print $2}')
+			WINEBIN_CODE=$(echo "${installArray[0]}" | awk -F' ' '{print $1}'); export WINEBIN_CODE
+			WINE_EXE=$(echo "${installArray[1]}" | awk -F' ' '{print $2}'); export WINE_EXE
 		elif [[ "${DIALOG}" == "zenity" ]]; then
 			column_names=(--column "Choice" --column "Code" --column "Description" --column "Path")
 			installationChoice=$(zenity --width=1024 --height=480 \


### PR DESCRIPTION
This PR fixes #178. It also makes the AppImage install the default and cleans up other code. Further, `-D|--debug` gains some new options, including automatically including `-V|--verbose`.