### PR TITLE
Output \n as newlines on console

### DIFF
--- a/LogosLinuxInstaller.sh
+++ b/LogosLinuxInstaller.sh
@@ -173,7 +173,7 @@ no-diag-msg() {
 	die;
 }
 cli_msg() {
-	printf "%s\n" "${1}"
+	printf "%s\n" "${1}" | sed 's/\\n/\n/g'
 }
 gtk_info() {
 	zenity --info --width=300 --height=200 --text="$*" --title='Information'


### PR DESCRIPTION
cli_msg got passed strings with \n in it. This was printed literally to the console, which was not really readable.

Convert \n to real newlines, so the console output is more readable.